### PR TITLE
automated publishing with travis, prepublish compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ logs
 *.log
 .grunt
 build
+dist
 node_modules
 coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+build
 coverage
 test
 .jscsrc

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+coverage
+test
+.jscsrc
+.travis.yml
+Gruntfile.js
+server.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: node_js
 node_js:
-  - "node"
+- node
 before_script:
-  - npm install grunt-cli -g
-  - export CHROME_BIN=chromium-browser
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - node server &
-  - sleep 3 # give server and xvfb some time to start
+- npm install grunt-cli -g
+- export CHROME_BIN=chromium-browser
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+- node server &
+- sleep 3
+deploy:
+  provider: npm
+  email: npm@vokal.io
+  api_key:
+    secure: apM6fiSstpoyIPpE4iolRKZw2FYWP3Bpo/nfSuwbD5MjX1Z5E1lnsIYrABBbzEtXFUHBAU4G+nFpeMV8wgCgcKoA6EM8EskQs/F29JkCGbImq6rwfGPBwf37WZXNWHV//LH+9A7x7Y/4wvUzJylxJ3srWiouyNxdQNwC8T1Y+hX2SJmDVMYYIt47nnPNZNGrquDZmp2dESt49MnFZW8AnN1ck0oFEufqSF+jhhRfmQt0frJfk7KXTQTbUDI0kxJkWXQNbhIXsY9bUMjR7qx4iZLlrEo3diu5VB8zWuL0rily+iVqqua2HbSPjawtQxMmODJ9UkpgbnBOsWfmz4UK7cZrECjNfLrQw0oiWjpSiSA33B1RC9A+pAJfC/jjZGZV8ualhanMi/h0iyu7w0LQXYwKH3/L5XgRO5tj9BdLoGj+nbE217hQy5NZ1ssdG0gdZUeoGKCRp7nSW171SUdPgHWNBe5l63y7Upr5MrDF/7OU/evNLblu/OCilwRrSwRrx8NBXDoW3w5U0KPLN3UlZU5sfcB5IQEtNfEbzqgwSrpnyvDSE0rydn+vqRwHILTDC9X6sxrZ+f66sgTMKuRqaR8I03OzlCWS+Oyii+ZYQEUHHOq5FmGO0y6x8/E78bT2CO2dt5SuKRNpfmIGWbZKHLVen8lzh3M8jlXXfzq5T0Q=
+  on:
+    tags: true
+    repo: vokal/angular-datetime

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,22 +1,31 @@
 "use strict";
 
+var browserifyTransforms = [ [ "babelify", { presets: [ "es2015" ] } ] ];
 module.exports = function ( grunt )
 {
     grunt.initConfig( {
         clean: {
+            build: [ "build/" ],
             coverage: [ "coverage/" ],
             dist: [ "dist/" ]
         },
         less: {
-            all:
-            {
+            all: {
                 files: {
-                    "build/angular-date-picker.css": "source/styles/angular-date-picker.less",
-                    "build/angular-time-picker.css": "source/styles/angular-time-picker.less"
+                    "dist/angular-date-picker.css": "source/styles/angular-date-picker.less",
+                    "dist/angular-time-picker.css": "source/styles/angular-time-picker.less"
                 }
             }
         },
         browserify: {
+            compile: {
+                options: { transform: browserifyTransforms },
+                files: {
+                    "dist/index.js": [ "source/index.js" ],
+                    "dist/angular-date-picker.js": [ "source/date-picker.js" ],
+                    "dist/angular-time-picker.js": [ "source/time-picker.js" ]
+                }
+            },
             test: {
                 options: {
                     transform: [
@@ -28,9 +37,8 @@ module.exports = function ( grunt )
                                 "**/source/time-picker.js",
                                 "**/source/index.js"
                             ]
-                        } ],
-                        [ "babelify", { presets: [ "es2015" ] } ]
-                    ],
+                        } ]
+                    ].concat( browserifyTransforms ),
                     browserifyOptions: {
                         debug: true
                     }
@@ -38,6 +46,15 @@ module.exports = function ( grunt )
                 files: {
                     "build/test.js": [ "test/harness/index.js" ],
                     "build/test-tz.js": [ "test/harness/index-tz.js" ]
+                }
+            }
+        },
+        uglify: {
+            compile: {
+                files: {
+                    "dist/index.min.js": "dist/index.js",
+                    "dist/angular-date-picker.min.js": "dist/angular-date-picker.js",
+                    "dist/angular-time-picker.min.js": "dist/angular-time-picker.js"
                 }
             }
         },
@@ -70,8 +87,10 @@ module.exports = function ( grunt )
     grunt.loadNpmTasks( "grunt-browserify" );
     grunt.loadNpmTasks( "grunt-contrib-clean" );
     grunt.loadNpmTasks( "grunt-contrib-less" );
+    grunt.loadNpmTasks( "grunt-contrib-uglify" );
     grunt.loadNpmTasks( "grunt-protractor-coverage" );
     grunt.loadNpmTasks( "grunt-istanbul" );
 
-    grunt.registerTask( "default", [ "clean", "less", "browserify", "protractor_coverage", "makeReport" ] );
+    grunt.registerTask( "test", [ "clean", "less", "browserify:test", "protractor_coverage", "makeReport" ] );
+    grunt.registerTask( "compile", [ "clean", "less", "browserify:compile", "uglify" ] );
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var browserifyTransforms = [ [ "babelify", { presets: [ "es2015" ] } ] ];
 module.exports = function ( grunt )
 {
     grunt.initConfig( {
@@ -18,14 +17,6 @@ module.exports = function ( grunt )
             }
         },
         browserify: {
-            compile: {
-                options: { transform: browserifyTransforms },
-                files: {
-                    "dist/index.js": [ "source/index.js" ],
-                    "dist/angular-date-picker.js": [ "source/date-picker.js" ],
-                    "dist/angular-time-picker.js": [ "source/time-picker.js" ]
-                }
-            },
             test: {
                 options: {
                     transform: [
@@ -37,8 +28,9 @@ module.exports = function ( grunt )
                                 "**/source/time-picker.js",
                                 "**/source/index.js"
                             ]
-                        } ]
-                    ].concat( browserifyTransforms ),
+                        } ],
+                        [ "babelify", { presets: [ "es2015" ] } ]
+                    ],
                     browserifyOptions: {
                         debug: true
                     }
@@ -46,15 +38,6 @@ module.exports = function ( grunt )
                 files: {
                     "build/test.js": [ "test/harness/index.js" ],
                     "build/test-tz.js": [ "test/harness/index-tz.js" ]
-                }
-            }
-        },
-        uglify: {
-            compile: {
-                files: {
-                    "dist/index.min.js": "dist/index.js",
-                    "dist/angular-date-picker.min.js": "dist/angular-date-picker.js",
-                    "dist/angular-time-picker.min.js": "dist/angular-time-picker.js"
                 }
             }
         },
@@ -87,10 +70,8 @@ module.exports = function ( grunt )
     grunt.loadNpmTasks( "grunt-browserify" );
     grunt.loadNpmTasks( "grunt-contrib-clean" );
     grunt.loadNpmTasks( "grunt-contrib-less" );
-    grunt.loadNpmTasks( "grunt-contrib-uglify" );
     grunt.loadNpmTasks( "grunt-protractor-coverage" );
     grunt.loadNpmTasks( "grunt-istanbul" );
 
     grunt.registerTask( "test", [ "clean", "less", "browserify:test", "protractor_coverage", "makeReport" ] );
-    grunt.registerTask( "compile", [ "clean", "less", "browserify:compile", "uglify" ] );
 };

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Both the date picker and the time picker require Moment as a dependency. Include
 
 ### Date Picker
 
-Add `dist/angular-date-picker.min.js` and `dist/angular-date-picker.css` to your project, and include `vokal.datePicker` in your module dependencies.
+Add `dist/angular-date-picker.js` and `dist/angular-date-picker.css` to your project, and include `vokal.datePicker` in your module dependencies.
 
 ```html
 <input type="text" data-ng-model="dateModel" data-date-picker[="M/D/YYYY"]
@@ -37,7 +37,7 @@ Supported zones are limited to those identifiable to `moment-timezone`, which ca
 
 ### Time Picker
 
-Add `dist/angular-time-picker.min.js` and `dist/angular-time-picker.css` to your project, and include `vokal.timePicker` in your module dependencies.
+Add `dist/angular-time-picker.js` and `dist/angular-time-picker.css` to your project, and include `vokal.timePicker` in your module dependencies.
 
 ```html
 <input type="text" data-ng-model="timeModel" data-time-picker[="h:mm a"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-datetime",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Basic date/time pickers for Angular.js",
   "homepage": "http://github.com/vokal/angular-datetime",
   "main": "source/index.js",
@@ -20,8 +20,8 @@
   "scripts": {
     "dist": "grunt dist",
     "start": "node server",
-    "webdriver-update": "node ./node_modules/protractor/bin/webdriver-manager update",
-    "test": "npm run webdriver-update && grunt"
+    "pretest": "node ./node_modules/protractor/bin/webdriver-manager update",
+    "test": "grunt"
   },
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "Basic date/time pickers for Angular.js",
   "homepage": "http://github.com/vokal/angular-datetime",
-  "main": "source/index.js",
+  "main": "dist/index.js",
   "bugs": {
     "url": "http://github.com/vokal/angular-datetime/issues"
   },
@@ -21,7 +21,8 @@
     "dist": "grunt dist",
     "start": "node server",
     "pretest": "node ./node_modules/protractor/bin/webdriver-manager update",
-    "test": "grunt"
+    "test": "grunt test",
+    "prepublish": "grunt compile"
   },
   "license": "MIT",
   "devDependencies": {
@@ -35,6 +36,7 @@
     "grunt-browserify": "^4.0.1",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-less": "^0.11.4",
+    "grunt-contrib-uglify": "^0.11.0",
     "grunt-istanbul": "^0.6.1",
     "grunt-protractor-coverage": "^0.2.15",
     "protractor": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,10 @@
     "url": "http://github.com/vokal/angular-datetime"
   },
   "scripts": {
-    "dist": "grunt dist",
     "start": "node server",
     "pretest": "node ./node_modules/protractor/bin/webdriver-manager update",
     "test": "grunt test",
-    "prepublish": "grunt compile"
+    "prepublish": "node scripts/compile.js"
   },
   "license": "MIT",
   "devDependencies": {
@@ -30,15 +29,15 @@
     "angular-mocks": "1.4.x",
     "babel-preset-es2015": "^6.1.2",
     "babelify": "^7.2.0",
+    "browserify": "^13.0.0",
     "browserify-istanbul": "^0.2.1",
     "express": "^4.13.3",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-contrib-clean": "^0.7.0",
-    "grunt-contrib-less": "^0.11.4",
-    "grunt-contrib-uglify": "^0.11.0",
     "grunt-istanbul": "^0.6.1",
     "grunt-protractor-coverage": "^0.2.15",
+    "less": "^2.5.3",
     "protractor": "^2.5.1",
     "protractor-axs": "github:vokal/protractor-axs",
     "q": "^1.4.1"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-contrib-clean": "^0.7.0",
+    "grunt-contrib-less": "^1.1.0",
     "grunt-istanbul": "^0.6.1",
     "grunt-protractor-coverage": "^0.2.15",
     "less": "^2.5.3",

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -41,8 +41,5 @@ try
     less.render( fs.readFileSync( obj.src ).toString(), {
         filename: obj.src
     } )
-        .then( output =>
-        {
-            return fs.writeFile( obj.dest, output.css );
-        } );
+        .then( output => fs.writeFile( obj.dest, output.css ) );
 } );

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -1,0 +1,48 @@
+var browserify = require( "browserify" );
+var less = require( "less" );
+var fs = require( "fs" );
+
+try
+{
+    fs.mkdirSync( "dist" );
+} catch( e )
+{
+    if( e.code != "EEXIST" )
+    {
+        throw e;
+    }
+}
+
+[ {
+    src: "source/date-picker.js",
+    dest: "dist/angular-date-picker.js"
+}, {
+    src: "source/time-picker.js",
+    dest: "dist/angular-time-picker.js"
+}, {
+    src: "source/index.js",
+    dest: "dist/index.js"
+} ].forEach( obj =>
+{
+    browserify( obj.src, {} )
+        .transform( "babelify", { presets: [ "es2015" ] } )
+        .bundle()
+        .pipe( fs.createWriteStream( obj.dest ) );
+} );
+
+[ {
+    src: "source/styles/angular-date-picker.less",
+    dest: "dist/angular-date-picker.css"
+}, {
+    src: "source/styles/angular-time-picker.less",
+    dest: "dist/angular-time-picker.css"
+} ].forEach( obj =>
+{
+    less.render( fs.readFileSync( obj.src ).toString(), {
+        filename: obj.src
+    } )
+        .then( output =>
+        {
+            return fs.writeFile( obj.dest, output.css );
+        } );
+} );

--- a/test/harness/harness-tz.html
+++ b/test/harness/harness-tz.html
@@ -9,8 +9,8 @@
         <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=0, width=360">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-        <link rel="stylesheet" href="/build/angular-date-picker.css">
-        <link rel="stylesheet" href="/build/angular-time-picker.css">
+        <link rel="stylesheet" href="/dist/angular-date-picker.css">
+        <link rel="stylesheet" href="/dist/angular-time-picker.css">
 
         <base href="/">
     </head>

--- a/test/harness/harness.html
+++ b/test/harness/harness.html
@@ -9,8 +9,8 @@
         <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=0, width=360">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-        <link rel="stylesheet" href="/build/angular-date-picker.css">
-        <link rel="stylesheet" href="/build/angular-time-picker.css">
+        <link rel="stylesheet" href="/dist/angular-date-picker.css">
+        <link rel="stylesheet" href="/dist/angular-time-picker.css">
 
         <base href="/">
     </head>


### PR DESCRIPTION
I've set it to force `tags: true` in the deploy script to only run the publish task when a tag is included. I've seen it described as being able to just add a tag through the github interface (and never through a pull request), so once this gets approval we can create the 3.0.1 tag to see if it works as anticipated
- formatting to the `.travis.yml` file was something the travis setup task did
- re-added `grunt-contrib-uglify` to create minified files in the `dist` directory

@jrit @Tathanen 
